### PR TITLE
Allow setting `docker_host` and `log_driver`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,13 @@
 A [default configuration](defaults/main.yml) is provided in this role. It establishes a cache service based on the freedesktop-sdk buildbox-casd Docker image with persistent storage. The following variables are defined:
 
 - `casd_cache`: the path to the cache on the host
+- `casd_docker_host`: The path (or address) to use to connect to the docker API, can be used for example to run the container with podman
 - `casd_image`: the Docker image to use in instantiating the container
 - `casd_container`: the container name
 - `casd_network`: the name of the Docker network to create and attach the service container to
 - `casd_network_connected_containers`: a list of containers to connect to the network being created for buildbox-casd
+- `casd_log_driver`: the log driver to use for the buildbox-casd container
+- `casd_log_options`: additional options to pass to the log driver
 - `casd_port`: the port the service listens to in the container and which is exposed on the container
 - `casd_published_ports`: a list of docker port specifications to be published. This does not affect whether the port on which buildbox-casd is listening is exposed.
 - `casd_bind_address`: the address the service listens to inside the container

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ casd_cache: "/srv/buildbox_casd/cache"
 casd_proxy_certdir: "/srv/buildbox_casd/certs"
 
 # container config
+casd_docker_host: "unix:///var/run/docker.sock"
 casd_image: "registry.gitlab.com/freedesktop-sdk/infrastructure/freedesktop-sdk-docker-images/buildbox-casd"
 casd_container: "buildbox-casd"
 casd_network: "{{ casd_container }}-net"
@@ -13,6 +14,8 @@ casd_network_connected_containers: []
 casd_port: 11001
 casd_publish_ports: []
 casd_labels: {}
+casd_log_driver: ""
+casd_log_options: {}
 
 # casd metrics
 # Must be one of udp://<statsd_server>:<port>, file://<path> or stderr

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,6 +56,7 @@
     name: "{{ casd_network }}"
     connected: "{{ [] if casd_bind_path else casd_network_connected_containers }}"
     appends: true
+    docker_host: "{{ casd_docker_host }}"
 
 - name: Bring up buildbox-casd
   community.docker.docker_container:
@@ -72,3 +73,6 @@
     labels: "{{ casd_labels }}"
     comparisons:
       '*': strict
+    docker_host: "{{ casd_docker_host }}"
+    log_driver: "{{ casd_log_driver }}"
+    log_options: "{{ casd_log_options }}"


### PR DESCRIPTION
These changes allow for more flexibility in the configuration of the container

For example it is possible to give the path of a `podman` socket in place of a `docker` socket.

It is also possible to switch to a different log-driver which handles log rotation.
