### PR TITLE
Add `casd_quota_low` variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A [default configuration](defaults/main.yml) is provided in this role. It establ
 - `casd_published_ports`: a list of docker port specifications to be published. This does not affect whether the port on which buildbox-casd is listening is exposed.
 - `casd_bind_address`: the address the service listens to inside the container
 - `casd_quota_high`: the maximum local cache size
+- `casd_quota_low`: local cache size to retain on LRU expiry, either as absolute size or as percentage of `casd_quota_high`
 - `casd_reserved`: Reserved disk space
 - `casd_cache_mnt`: the path to bindmount the cache to in the container
 - `casd_cmd`: the entrypoint of the container

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,11 +33,13 @@ casd_bind_path: ""
 casd_bind: "{{ 'unix:' ~ casd_bind_path if casd_bind_path else casd_bind_address ~ ':' ~ casd_port }}"
 casd_quota_high: ""
 casd_reserved: ""
+casd_quota_low: ""
 casd_cache_mnt: "/srv"
 casd_certs_mnt: "/certs"
 casd_cmd: >-
   --verbose --bind {{ casd_bind }}
   {% if casd_quota_high %}--quota-high {{ casd_quota_high }}{% endif %}
+  {% if casd_quota_low %}--quota-low {{ casd_quota_low }}{% endif %}
   {% if casd_reserved %}--reserved {{ casd_reserved }}{% endif %}
   {{ casd_metrics_args }} {{ casd_proxy_cas_args }} {{ casd_proxy_ac_args }}
   {{ casd_proxy_asset_args }} {{ casd_proxy_execution_args }} {{ casd_cache_mnt }}


### PR DESCRIPTION
This variable allows the user to specify the value of the `--quota-low` command line option for casd