### PR TITLE
Add `casd_reserved` var and change default args

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A [default configuration](defaults/main.yml) is provided in this role. It establ
 - `casd_published_ports`: a list of docker port specifications to be published. This does not affect whether the port on which buildbox-casd is listening is exposed.
 - `casd_bind_address`: the address the service listens to inside the container
 - `casd_quota_high`: the maximum local cache size
+- `casd_reserved`: Reserved disk space
 - `casd_cache_mnt`: the path to bindmount the cache to in the container
 - `casd_cmd`: the entrypoint of the container
 - `casd_bind_path`: path to a UNIX socket to serve on.  If set, `casd_bind_address` and `casd_port` are ignored entirely and the service is not exposed.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,11 +31,14 @@ casd_metrics_args: >-
 casd_bind_address: "0.0.0.0"
 casd_bind_path: ""
 casd_bind: "{{ 'unix:' ~ casd_bind_path if casd_bind_path else casd_bind_address ~ ':' ~ casd_port }}"
-casd_quota_high: "200G"
+casd_quota_high: ""
+casd_reserved: ""
 casd_cache_mnt: "/srv"
 casd_certs_mnt: "/certs"
 casd_cmd: >-
-  --verbose --bind {{ casd_bind }} --quota-high {{ casd_quota_high }}
+  --verbose --bind {{ casd_bind }}
+  {% if casd_quota_high %}--quota-high {{ casd_quota_high }}{% endif %}
+  {% if casd_reserved %}--reserved {{ casd_reserved }}{% endif %}
   {{ casd_metrics_args }} {{ casd_proxy_cas_args }} {{ casd_proxy_ac_args }}
   {{ casd_proxy_asset_args }} {{ casd_proxy_execution_args }} {{ casd_cache_mnt }}
 casd_default_mounts:


### PR DESCRIPTION
`casd_reserved` allows specifying a value for the `--reserved` flag. To accomodate using this the default arguments passed to buildbox-casd have changed to avoid always setting the `--quota-high` flag.

This is a breaking change as there is no longer an implicit value of `casd_quota_high`.